### PR TITLE
Add help panel

### DIFF
--- a/src/controller.py
+++ b/src/controller.py
@@ -5,6 +5,7 @@ from prompt_toolkit.completion import Completer, Completion
 from contacts import cntcts_controller
 from context import data_cxt_mngr
 from output import output_warning
+from output.help_ import show_help_panels
 
 COMMAND_TREE = {
     "contacts": [
@@ -77,18 +78,7 @@ def bootstrap():
                             f"{Fore.BLUE}************** Notes **************{Fore.RESET}"
                         )
                     case "help":
-                        print(
-                            "Available commands:\n"
-                            f"{Fore.CYAN}add {Fore.GREEN}[Name] [Phone Number]{Fore.RESET}- create new record\n"
-                            f"{Fore.CYAN}change {Fore.GREEN}[Name] [New Phone Number]{Fore.RESET}- change phone number by [Name]\n"
-                            f"{Fore.CYAN}phone {Fore.GREEN}[Phone Number]{Fore.RESET}- display owner name\n"
-                            f"{Fore.CYAN}all {Fore.RESET}- list all users with their number\n"
-                            f"{Fore.CYAN}add-birthday {Fore.GREEN}[Name] [DD.MM.YYYY]{Fore.RESET}- add to provided contact its birthday\n"
-                            f"{Fore.CYAN}show-birthday {Fore.GREEN}[Name]{Fore.RESET}- display contacts birthday\n"
-                            f"{Fore.CYAN}birthdays {Fore.RESET}- show contacts which have birthdays in next 7 days\n"
-                            f"{Fore.CYAN}help {Fore.RESET}- display commands list\n"
-                            f"{Fore.CYAN}exit | close {Fore.RESET}- close the program"
-                        )
+                        show_help_panels()
                     case _:
                         output_warning(
                             f"Unknown command: [{Fore.RED}{command}{Fore.RESET}]. Please, use [{Fore.CYAN}help{Fore.RESET}] to see available commands."

--- a/src/output/help_.py
+++ b/src/output/help_.py
@@ -1,0 +1,68 @@
+from rich import box
+from rich.align import Align
+from rich.columns import Columns
+from rich.console import Console
+from rich.panel import Panel
+
+
+def show_help_panels():
+    console = Console()
+
+    contacts_text = """
+    📞 [cyan]add [green][Name] [Phone Number][/green][/cyan] [white]- create new record[/white]
+    [cyan]change [green][Name] [New Phone Number][/green][/cyan] [white]- change phone number by [Name][/white]
+    [cyan]phone [green][Phone Number][/green][/cyan] [white]- display owner name[/white]
+    [cyan]all[/cyan] [white]- list all users with their number[/white]
+    [cyan]add-birthday [green][Name] [DD.MM.YYYY][/green][/cyan] [white]- add to provided contact its birthday[/white]
+    [cyan]show-birthday [green][Name][/green][/cyan] [white]- display contacts birthday[/white]
+    [cyan]birthdays[/cyan] [white]- show contacts which have birthdays in next 7 days[/white]
+    """
+
+    notes_text = """
+    for example:
+
+    [cyan]add-note ----------------------------------------[/cyan]
+    [cyan]edit-note 
+    [cyan]delete-note 
+    [cyan]search-notes 
+    """
+
+    extra_text = """
+    ❓ [cyan]help[/cyan] [white]- display commands list
+    🚪 [cyan]exit | close[/cyan] [white]- close the program
+    """
+
+    panel_height = 11
+
+    header_panel = Panel(
+        Align.center("📘 [b]AVAILABLE COMMANDS[/b] 📘", vertical="middle"),
+        style="green on black",
+        padding=(0, 71),
+        expand=False,
+        box=box.DOUBLE,
+    )
+
+    contact_panel = Panel(
+        contacts_text,
+        title="📇 [b]CONTACTS[/b]",
+        border_style="green",
+        height=panel_height,
+        style="green on black",
+    )
+    notes_panel = Panel(
+        notes_text,
+        title="📝 [b]NOTES[/b]",
+        border_style="blue",
+        height=panel_height,
+        style="green on black",
+    )
+    extra_panel = Panel(
+        extra_text,
+        title="⚙️  [b]ADDITIONAL COMMANDS[/b]",
+        border_style="magenta",
+        height=panel_height,
+        style="green on black",
+    )
+
+    console.print(header_panel)
+    console.print(Columns([contact_panel, notes_panel, extra_panel]))


### PR DESCRIPTION
A new module help_.py was created in the outputs directory, containing the show_help_panels() function implemented using the rich library.
The function was imported into controller.py to display the help panel when the help command is triggered.
The output is now visually enhanced with a 3-column layout (Contacts, Notes, Additional Commands).